### PR TITLE
Garbage Collect Sections On AVR

### DIFF
--- a/avr.toolchain
+++ b/avr.toolchain
@@ -15,7 +15,7 @@ add_definitions(
     -DF_CPU=${F_CPU}
 )
 
-set(CMAKE_EXE_LINKER_FLAGS -mmcu=${MCU})
+set(CMAKE_EXE_LINKER_FLAGS "-mmcu=${MCU} -Wl,--gc-sections")
 add_compile_options(
     -mmcu=${MCU} # MCU
 )


### PR DESCRIPTION
Reduces code size for the binary output.

Fixes an issue, where the code couldn't be successfully compiled for AVR because the `.text` section overflowed the available storage.