### PR TITLE
Enable custom RNG implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,11 @@ if(NOT USE_SOFTWARE_CRYPTO_SHA512)
     add_compile_definitions(NO_SOFTWARE_CRYPTO_SHA512)
 endif()
 
+option(USE_SOFTWARE_RNG "include software RNG" ON)
+if(NOT USE_SOFTWARE_RNG)
+    add_compile_definitions(NO_SOFTWARE_RNG)
+endif()
+
 #######################################
 # External libraries
 

--- a/examples/esp32/main/esp32-libmicrofido2.c
+++ b/examples/esp32/main/esp32-libmicrofido2.c
@@ -30,7 +30,7 @@ int app_main(void) {
     clock_start_counting();
     const int ret = stateless_assert(&dev, "example.com", updater_public_key);
     uint64_t elapsed_cycles = clock_stop_counting();
-    printf("Elapsed cycles for stateless assertion: %zu\n", elapsed_cycles);
-    printf("Elapsed nanoseconds for stateless assertion: %zu\n", clock_cyles_to_ns(elapsed_cycles));
+    printf("Elapsed cycles for stateless assertion: %llu\n", elapsed_cycles);
+    printf("Elapsed nanoseconds for stateless assertion: %lu\n", clock_cyles_to_ns(elapsed_cycles));
     return ret;
 }

--- a/include/fido.h
+++ b/include/fido.h
@@ -24,3 +24,4 @@
 #include "largeblob.h"
 #include "nfc.h"
 #include "param.h"
+#include "random.h"

--- a/include/internal.h
+++ b/include/internal.h
@@ -15,7 +15,6 @@
 
 int fido_rx(fido_dev_t *d, const uint8_t cmd, void *buf, const size_t len);
 int fido_tx(fido_dev_t *d, const uint8_t cmd, const void *buf, const size_t len);
-int fido_get_random(void *buf, size_t len);
 
 /**
  * @brief Read from a given buffer, copying the data and checking for overflow.

--- a/include/random.h
+++ b/include/random.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Felix Gohla, Konrad Hanff, Tobias Kantusch,
+ *                    Quentin Kuth, Felix Roth. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @brief Random number generation
+ *
+ * @param buf Pointer to the buffer to write the random bytes to.
+ * @param random_len Amount of random bytes to generate.
+ * @return int FIDO_OK when the random data was written successfully
+ */
+typedef int (*fido_get_random_t)(
+    const uint8_t *buf,
+    size_t random_len
+);
+
+/**
+ * This is a pointer to a function for random number generation.
+ * It can be set to other functions, for example when the platform provides
+ * hardware support for RNGs.
+ *
+ * fido_get_random = &my_hardware_rng;
+ *
+ * You can define the macro NO_SOFTWARE_RNG to prevent the software implementation
+ * of this algorithm to be included in the library.
+ */
+extern fido_get_random_t fido_get_random;

--- a/src/assertion.c
+++ b/src/assertion.c
@@ -330,7 +330,7 @@ static int fido_dev_get_assert_wait(
 
     if ((r = fido_dev_get_assert_tx(dev, assert, pk, ecdh)) != FIDO_OK ||
         (r = fido_dev_get_assert_rx(dev, assert, reply)) != FIDO_OK)
-        return (r);
+        return r;
 
     return FIDO_OK;
 }
@@ -401,16 +401,16 @@ static int fido_check_flags(fido_assert_auth_data_flags_t auth_data_flags, fido_
     if (up == FIDO_ASSERT_OPTION_UP &&
         ((auth_data_flags & FIDO_AUTH_DATA_FLAGS_UP) == FIDO_AUTH_DATA_FLAGS_UP) == 0) {
         fido_log_debug("%s: CTAP_AUTHDATA_USER_PRESENT", __func__);
-        return (-1); /* user not present */
+        return -1; /* user not present */
     }
 
     if (uv == FIDO_ASSERT_OPTION_UV &&
         ((auth_data_flags & FIDO_AUTH_DATA_FLAGS_UV) == FIDO_AUTH_DATA_FLAGS_UV) == 0) {
         fido_log_debug("%s: CTAP_AUTHDATA_USER_VERIFIED", __func__);
-        return (-1); /* user not verified */
+        return -1; /* user not verified */
     }
 
-    return (0);
+    return 0;
 }
 
 static int fido_check_rp_id(const fido_assert_blob_t *rp_id, const uint8_t *obtained_hash) {

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2022 Felix Gohla, Konrad Hanff, Tobias Kantusch,
+ *                    Quentin Kuth, Felix Roth. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #include <aes_gcm.h>
 #include <sha256.h>
 #include <monocypher-ed25519.h>

--- a/src/dev.c
+++ b/src/dev.c
@@ -96,7 +96,7 @@ static int fido_dev_open_tx(fido_dev_t *dev) {
     /*
     if (dev->x != NULL) {
         fido_log_debug("%s: handle=%p", __func__, dev->io_handle);
-        return (FIDO_ERR_INVALID_ARGUMENT);
+        return FIDO_ERR_INVALID_ARGUMENT;
     }*/
 
     if (dev->io.open == NULL || dev->io.close == NULL) {

--- a/src/dev.c
+++ b/src/dev.c
@@ -101,17 +101,22 @@ static int fido_dev_open_tx(fido_dev_t *dev) {
 
     if (dev->io.open == NULL || dev->io.close == NULL) {
         fido_log_debug("%s: NULL open/close", __func__);
-        return (FIDO_ERR_INVALID_ARGUMENT);
+        return FIDO_ERR_INVALID_ARGUMENT;
     }
 
-    if (fido_get_random(&dev->nonce, sizeof(dev->nonce)) < 0) {
+    if(fido_get_random == NULL) {
+        fido_log_debug("%s: fido_get_random is NULL", __func__);
+        return FIDO_ERR_INTERNAL;
+    }
+
+    if (fido_get_random((uint8_t*) &dev->nonce, sizeof(dev->nonce)) < 0) {
         fido_log_debug("%s: fido_get_random", __func__);
-        return (FIDO_ERR_INTERNAL);
+        return FIDO_ERR_INTERNAL;
     }
 
     if ((dev->io_handle = dev->io.open()) == NULL) {
         fido_log_debug("%s: dev->io.open", __func__);
-        return (FIDO_ERR_INTERNAL);
+        return FIDO_ERR_INTERNAL;
     }
 
     if (fido_tx(dev, CTAP_CMD_INIT, &dev->nonce, sizeof(dev->nonce)) < 0) {
@@ -120,12 +125,12 @@ static int fido_dev_open_tx(fido_dev_t *dev) {
         goto fail;
     }
 
-    return (FIDO_OK);
+    return FIDO_OK;
 fail:
     dev->io.close(dev->io_handle);
     dev->io_handle = NULL;
 
-    return (r);
+    return r;
 }
 
 static int fido_dev_open_rx(fido_dev_t *dev) {

--- a/src/io.c
+++ b/src/io.c
@@ -17,7 +17,7 @@ int fido_tx(fido_dev_t *d, const uint8_t cmd, const void *buf, const size_t len)
 
     if (d->io_handle == NULL || d->io.write == NULL || d->transport.tx == NULL || len > UINT16_MAX) {
         fido_log_debug("%s: invalid argument", __func__);
-        return (FIDO_ERR_INVALID_ARGUMENT);
+        return FIDO_ERR_INVALID_ARGUMENT;
     }
 
     return d->transport.tx(d, cmd, buf, len);
@@ -29,7 +29,7 @@ int fido_rx(fido_dev_t *d, const uint8_t cmd, void *buf, const size_t len) {
 
     if (d->io_handle == NULL || d->io.read == NULL || d->transport.rx == NULL || len > UINT16_MAX) {
         fido_log_debug("%s: invalid argument", __func__);
-        return (FIDO_ERR_INVALID_ARGUMENT);
+        return FIDO_ERR_INVALID_ARGUMENT;
     }
 
     // Values below 0 are errors.

--- a/src/random.c
+++ b/src/random.c
@@ -11,7 +11,12 @@
 
 #include <stdint.h>
 
-int fido_get_random(void *buf, size_t len) {
+#if defined(NO_SOFTWARE_RNG)
+fido_get_random_t fido_get_random = NULL;
+#else
+int get_random(const uint8_t *buf, size_t random_len) {
     // TODO: Implement randomness here according to the standard.
     return 0;
 }
+fido_get_random_t fido_get_random = get_random;
+#endif


### PR DESCRIPTION
Similar to how custom crypto implementations can be used, this enables users to overwrite the RNG function.

Closes #41 