### PR TITLE
Fix building for Desktops by removing measurements auto-build

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,8 +9,3 @@ target_link_libraries(nfc ${PRODUCT_NAME})
 add_executable(nfc_simulator nfc_simulator.c stateless_rp/stateless_rp.c stateless_rp/stateless_rp_nfc_simulator.c)
 add_linker_map_for_target(nfc_simulator)
 target_link_libraries(nfc_simulator ${PRODUCT_NAME})
-
-#######################################
-# Test applications
-
-add_subdirectory(measurements/atmega)


### PR DESCRIPTION
Previously, we'd automatically built the measurements for the
ATmega when building the examples. However, as the library and
examples can be built for x86 as well, we should not do so as this
breaks that build.

Closes #49 